### PR TITLE
Update action.yml to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ branding:
   icon: 'shield'
   color: 'blue'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appknox-github-action",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Appknox Gtihub Action",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
GitHub reports that node@12 is no longer supported. Bumping the action to node@16 seems to work without issues from my limited tests. I think you’ll need to bump the version or else the behavior can be inconsistent in case the plugin is cached somewhere.